### PR TITLE
Use package name and version number in file name

### DIFF
--- a/app/src/main/java/com/tomclaw/appsend_rb/util/Files.kt
+++ b/app/src/main/java/com/tomclaw/appsend_rb/util/Files.kt
@@ -8,7 +8,7 @@ import com.tomclaw.appsend_rb.dto.AppEntity
 import java.io.File
 
 fun getApkPrefix(item: AppEntity): String {
-    return escapeFileSymbols(item.label + "-" + item.versionCode)
+    return escapeFileSymbols(item.packageName + "_" + item.versionName)
 }
 
 fun getApkSuffix(): String {


### PR DESCRIPTION
This PR changes the exported file name to the package name and the proper version number, like:
com.tomclaw.appsend_rb_2.0.apk

I think this is way more useful than just the app name and an internal version code.